### PR TITLE
Fea/automapper service

### DIFF
--- a/Pathos/Models/ErrorViewModel.cs
+++ b/Pathos/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Pathos.Models
 {
     public class ErrorViewModel

--- a/Pathos/Models/Mappings/ConfigurationProfile.cs
+++ b/Pathos/Models/Mappings/ConfigurationProfile.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using Microsoft.Extensions.Configuration;
+using Pathos.Models.Settings;
+
+namespace Pathos.Models.Mappings
+{
+    public class ConfigurationProfile : Profile
+    {
+        public ConfigurationProfile()
+        {
+            CreateMap<IConfiguration, AppSecrets>()
+                        .ForMember(o => o.SamplePassword, opt => opt.MapFrom(src => src["SamplePassword"]));
+        }
+    }
+}

--- a/Pathos/Models/Mappings/Engine.cs
+++ b/Pathos/Models/Mappings/Engine.cs
@@ -1,0 +1,18 @@
+﻿using AutoMapper;
+
+namespace Pathos.Models.Mappings
+{
+    public static class Engine
+    {
+        public static IMapper Mapper { get; internal set; }
+
+        static Engine()
+        {
+            Mapper = new MapperConfiguration(
+                cfg => {
+                    cfg.AddProfile<ConfigurationProfile>();
+                }
+            ).CreateMapper();
+        }
+    }
+}

--- a/Pathos/Pathos.csproj
+++ b/Pathos/Pathos.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="6.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
   </ItemGroup>
 

--- a/Pathos/Program.cs
+++ b/Pathos/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Pathos
 {

--- a/Pathos/Startup.cs
+++ b/Pathos/Startup.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Pathos/Startup.cs
+++ b/Pathos/Startup.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Pathos.Models.Mappings;
 using Pathos.Models.Settings;
 
 namespace Pathos
@@ -31,6 +32,8 @@ namespace Pathos
             services.Configure<AppSettings>(appSettings);
 
             services.Configure<AppSecrets>(Configuration);
+
+            services.AddSingleton(Engine.Mapper);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
This PR accompanies registering custom services section of the 12 Labours tutorial and Resolves issue #2 

1. AutoMapper Nuget package installed
2. A Static AutoMapper instance was registered as a Singleton

## Creating Mappings
Create a file following the convention <model-name>ModelProfile.cs. The class needs to extend AutoMapper's `Profile` class and call `CreateMap<TSource, TDestination>` in a public constructor. Ad this profile to the static constructor in Engine.cs by adding `cfg.AddProfile<Profile-You-Created>();`